### PR TITLE
웹페이지의 경계를 넘어 가로로 오버스크롤 됨을 막습니다

### DIFF
--- a/components/layout/index.tsx
+++ b/components/layout/index.tsx
@@ -29,7 +29,7 @@ export const Layout: React.FC<{ children: React.ReactNode }> = ({
 
     return (
         <div
-            style={{display: "flex", flexDirection: "column", minHeight: "100vh"}}
+            style={{display: "flex", flexDirection: "column", minHeight: "100vh", overflowX: "hidden"}}
         >
             <Header/>
             {children}


### PR DESCRIPTION
트랙패드 혹은 쉬프트+스크롤을 이용할 때 **웹페이지 전체가 가로 방향으로 오버스크롤**됩니다
https://user-images.githubusercontent.com/46598063/182643960-57acd6c1-cc50-4344-b2c5-5c14029d6d54.mp4

따라서 이를 막기 위해서 components/layout/index.tsx 에 **overflowX: "hidden"** 을 추가해 주었습니다
(그러나 더 나은 방법이 있을 수도 있습니다. 필요에 맞게 검토해주세요!)
